### PR TITLE
Build with -nostdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CC = ${CROSS}-gcc
 AS = ${CROSS}-as
 LD = ${CROSS}-ld
 OBJDUMP = ${CROSS}-objdump
-CFLAGS =  -mcpu=cortex-a57 -Wall -Wextra -g
+CFLAGS =  -mcpu=cortex-a57 -Wall -Wextra -g -nostdlib
 #	-mcpu=name
 #		Specify the name of the target processor
 #	-Wall

--- a/kernel.c
+++ b/kernel.c
@@ -25,12 +25,11 @@ void exception_svc_test(void)
 	exception_svc();
 
 	// Wait for Interrupt.
-	wfi();
 	uart_puts("exception_svc_test... done\n");
 }
 
 int main(void) {
-	//exception_svc_test();
+	exception_svc_test();
 	timer_test();
 }
 


### PR DESCRIPTION
Otherwise, the build fails on Ubuntu 16.04 with:

    undefined reference to `__stack_chk_guard'

since stack protection is turned on by default there.